### PR TITLE
feat: 커서 추가, 커서 색상 변경, 라인색 변경, 라인 지우기 기능 추가

### DIFF
--- a/src/utils/drawCursor.js
+++ b/src/utils/drawCursor.js
@@ -1,9 +1,10 @@
-export function drawCursor(result, ctx, x, y) {
+export function drawCursor(result, ctx, x, y, color) {
   if (result.handednesses.length > 0) {
     if (result.handednesses[0][0].categoryName === "Left") {
       ctx.beginPath();
       ctx.clearRect(0, 0, 960, 540);
       ctx.arc(x, y, 1, 0, 2 * Math.PI);
+      ctx.fillStyle = color;
       ctx.fill();
     }
   }

--- a/src/utils/drawCursor.js
+++ b/src/utils/drawCursor.js
@@ -1,0 +1,10 @@
+export function drawCursor(result, ctx, x, y) {
+  if (result.handednesses.length > 0) {
+    if (result.handednesses[0][0].categoryName === "Left") {
+      ctx.beginPath();
+      ctx.clearRect(0, 0, 960, 540);
+      ctx.arc(x, y, 1, 0, 2 * Math.PI);
+      ctx.fill();
+    }
+  }
+}

--- a/src/utils/drawLine.js
+++ b/src/utils/drawLine.js
@@ -1,5 +1,4 @@
 export function drawLine(result, ctx, x, y) {
-  console.log(result);
   if (result.handednesses.length > 0) {
     if (
       result.handednesses[0][0].categoryName === "Left" &&

--- a/src/utils/drawLine.js
+++ b/src/utils/drawLine.js
@@ -1,11 +1,12 @@
-export function drawLine(result, ctx, x, y) {
+export function drawLine(result, ctx, x, y, color, mode) {
   if (result.handednesses.length > 0) {
-    if (
-      result.handednesses[0][0].categoryName === "Left" &&
-      result.gestures[0][0].categoryName === "Open_Palm"
-    ) {
+    if (mode === "Move") {
+      ctx.beginPath();
       ctx.moveTo(x, y);
-    } else if (result.handednesses[0][0].categoryName === "Left") {
+    } else if (mode === "Erase") {
+      ctx.clearRect(x, y, 10, 10);
+    } else if (mode === "Draw") {
+      ctx.strokeStyle = color;
       ctx.lineTo(x, y);
       ctx.stroke();
     }

--- a/src/utils/toolHand.js
+++ b/src/utils/toolHand.js
@@ -1,0 +1,30 @@
+let prevCount = 0;
+let nextCount = 0;
+const color = ["red", "orange", "yellow", "blue", "green", "black"];
+let index = 0;
+
+export function prevColor(setColor) {
+  prevCount++;
+
+  if (prevCount > 20) {
+    setColor(color[index]);
+    prevCount = 0;
+    index--;
+    if (index < 0) {
+      index = color.length - 1;
+    }
+  }
+}
+
+export function nextColor(setColor) {
+  nextCount++;
+
+  if (nextCount > 20) {
+    setColor(color[index]);
+    nextCount = 0;
+    index++;
+    if (index > color.length - 1) {
+      index = 0;
+    }
+  }
+}


### PR DESCRIPTION
## ✔️PR타입

- 기능 구현
- 기능 수정

## ✔️개요

- 그림이 그려지는 커서를 구현하기 위하여 `cursorCanvas`를 추가하였습니다.
- 색변경을 위하여 `color` state를 추가하고 모드 변경을 위한 `mode` state를 추가하였습니다.
- video 로딩 부분을 promise 방식에서 async/await 방식으로 변경하였습니다.
- 왼손 `Thumb_Up`에 다음 색상 `Thumb_Down`에 이전 색상이 그려지도록 구현하였습니다.
- 오른을 `Move`, `Erase`, `Draw` 모드로 나누어 state로 관리하도록 변경하였습니다.
- `requestAnimationFrame` 방식에서 `setInterval` 방식으로 구현방식을 변경하였습니다.
- 커서를 표현하는 `drawCursor.js` 파일을 생성하였습니다.

## ✔️변경사항

1. 그림이 그려지는 시작점을 구현하기 위하여 `cursorCanvas`를 추가하고 `drawCursor.js`파일과  함수를 만들어 `canvas`에 구현하였습니다.
2. Draw 시 그려지는 라인의 색을 변경하기 위하여 `color`라는 State를 추가하였습니다.
3. `Move`, `Draw`, `Erase` 모드를 관리하기 위한 `mode` State를 추가하였습니다.
4. video 로딩 useEffect 코드를 코드 간결화를 위하여 `promise`방식에서 `async/await` 방식으로 변경하였습니다.
5. 왼손 `Thumb_Up`을 일정 기간 유지하면 다음 색상이 선택되고 `Thumb_Down`을 일정 기간 유지하면 이전 색상이 선택되는 기능을 module 스코프를 사용하여 함수호출 횟수를 카운트하는 방식으로 구현하였습니다.
6. 오른손 제스처를 `Open_Palm`, `Victory` 그 외로 나누고 `Open_Palm`인 경우 `Move`, `Victory`인 경우 `Erase`, 그 외의 경우 `Draw`로 설정하고 상태를 관리하였습니다.
7. `requestAnimationFrame`을 사용할 시 `useEffect`의 의존성 배열에 `color`와 `model`을 추가했을 때 함수를 중첩해서 반복하는 현상이 있어 `setInterval`과 `clearInterval`를 사용하여 수정하였습니다.

## ✔️이슈

1. 양손을 인식한 경우 색 변경 기능이 동작하지 않습니다.
2. 오른손 모드 변경도 일정 기간 유지시 모드 변경으로 로직 수정 필요합니다.
3. `Erase`모드 시 가끔 안지워 지는 현상 수정 필요합니다.

## ✔️스크린샷

<img width="1452" alt="스크린샷 2023-04-12 오전 1 14 00" src="https://user-images.githubusercontent.com/107802867/231230523-ea23184b-5837-4335-8c1f-a2236d8304e2.png">


